### PR TITLE
Added missing ampersand-model dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "ampersand-router": "^1.0.6",
     "ampersand-view": "^7.2.0",
     "ampersand-view-switcher": "^1.1.2",
+    "ampersand-model": "^6.0.1",
     "domify": "^1.3.1",
     "domready": "^1.0.7",
     "get-result": "^0.1.0",


### PR DESCRIPTION
Added missing ampersand-model dependency. Website throws error without that.
